### PR TITLE
:zap: Move `cli.js` to `bin/`

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,7 @@ require('ts-node').register({
 });
 
 if (program.init) {
-    require('./src/init.ts');
+    require('../src/init.ts');
 } else {
-    require('./src/run.ts');
+    require('../src/run.ts');
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
     "description": "An easy way to see new notifications on the EDUX platform.",
     "main": "cli.js",
     "scripts": {
-        "config": "./cli.js --init",
-        "start": "./cli.js",
+        "config": "./bin/cli.js --init",
+        "start": "./bin/cli.js",
         "lint": "tsc --noEmit -p . && tslint \"*.ts\"",
         "test": "tsc --noEmit -p . && jest --no-cache"
     },
     "bin": {
-        "check-edux": "./cli.js"
+        "check-edux": "./bin/cli.js"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Move `cli.js` to the `bin/` folder Part of preparation to publish the package.